### PR TITLE
Added support for '&' when verifying valid ASN.1 printable string value

### DIFF
--- a/src/Asn1/Element/PrintableString.php
+++ b/src/Asn1/Element/PrintableString.php
@@ -88,7 +88,7 @@ class PrintableString implements TaggableElement
     public function setValue($value)
     {
         $value = (string) $value;
-        if (!preg_match('/^[A-Za-z0-9 \'()+,\-.\/:=?]*$/', $value)) {
+        if (!preg_match('/^[A-Za-z0-9 &\'()+,\-.\/:=?]*$/', $value)) {
             throw InvalidAsn1Value::create('Invalid ASN.1 PrintableString value');
         }
         $this->value = (string) $value;


### PR DESCRIPTION
Hi sir, great library! 

I was having some trouble while checking for the certificate status when string values contained the "&" character. 
Exploring the code I bumped into that regex that excludes the character in question, I added "&" to the regex validation. 

Works great!

Have a nice day!

