### PR TITLE
Fix implicitly nullable parameter declarations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,12 +33,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - windows-latest
         composer-flags:
-          - ""
+          - "--prefer-lowest"
+          - "--prefer-stable"
         php-version:
-          - "5.5"
-          - "5.6"
-          - "7.0"
           - "7.1"
           - "7.2"
           - "7.3"
@@ -46,22 +45,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
-        include:
-          - os: ubuntu-latest
-            php-version: "5.5"
-            composer-flags: "--prefer-lowest"
-          - os: ubuntu-latest
-            php-version: "7.3"
-            composer-flags: "--prefer-lowest"
-          - os: ubuntu-latest
-            php-version: "8.2"
-            composer-flags: "--prefer-lowest"
-          - os: windows-latest
-            php-version: "5.5"
-          - os: windows-latest
-            php-version: "7.4"
-          - os: windows-latest
-            php-version: "8.2"
+          - "8.3"
+          - "8.4"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set code coverage
@@ -76,9 +61,6 @@ jobs:
           coverage: ${{ env.CODE_COVERAGE_TOOL }}
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Patch composer
-        if: contains(matrix.composer-flags, '--prefer-lowest') && !contains(fromJSON('["5.5"]'), matrix.php-version)
-        run: composer require --no-update --ansi --no-interaction "phpunit/phpunit:^5.7 || ^6.5 || ^7.4 || ^8.5.23 || ^9.5"
       - name: Install Composer dependencies ${{ matrix.composer-flags }}
         run: composer --ansi --no-interaction --no-progress --optimize-autoloader ${{ matrix.composer-flags }} update
       - name: Run PHPUnit (without code coverage)

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "homepage": "https://github.com/mlocati/ocsp/",
     "support": {
-	    "issues": "https://github.com/mlocati/ocsp/issues/",
-	    "source": "https://github.com/mlocati/ocsp/"
+        "issues": "https://github.com/mlocati/ocsp/issues/",
+        "source": "https://github.com/mlocati/ocsp/"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,
@@ -33,15 +33,15 @@
         }
     },
     "require": {
-        "php": ">=5.5.9",
-        "phpseclib/phpseclib": "^2 || ^3"
+        "php": ">=7.1",
+        "phpseclib/phpseclib": "^2.0.47 || ^3.0.36"
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.4 || ^8.5.23 || ^9.5"
+        "phpunit/phpunit": "^7.4 || ^8.5.23 || ^9.5"
     },
     "scripts": {
-	    "codestyle": "php-cs-fixer fix --path-mode=intersection --config=.php-cs-fixer.dist.php .",
+        "codestyle": "php-cs-fixer fix --path-mode=intersection --config=.php-cs-fixer.dist.php .",
         "test": "phpunit"
     },
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "phpseclib/phpseclib": "^2.0.47 || ^3.0.36"
+        "phpseclib/phpseclib": "^2 || ^3"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Asn1/Der/Encoder.php
+++ b/src/Asn1/Der/Encoder.php
@@ -154,7 +154,7 @@ class Encoder implements EncoderInterface
      *
      * @return string
      */
-    protected function doEncodeElement(Element $element, Tag $implicitTag = null)
+    protected function doEncodeElement(Element $element, ?Tag $implicitTag = null)
     {
         if ($implicitTag === null) {
             $result = $this->encodeType($element->getTypeID(), $element->getClass(), $element->isConstructed());

--- a/src/Asn1/TaggableElement.php
+++ b/src/Asn1/TaggableElement.php
@@ -21,5 +21,5 @@ interface TaggableElement extends Element
      *
      * @return $this
      */
-    public function setTag(Tag $value = null);
+    public function setTag(?Tag $value = null);
 }

--- a/src/Asn1/TaggableElementTrait.php
+++ b/src/Asn1/TaggableElementTrait.php
@@ -29,7 +29,7 @@ trait TaggableElementTrait
      *
      * @see \Ocsp\Asn1\TaggableElement::setTag()
      */
-    public function setTag(Tag $value = null)
+    public function setTag(?Tag $value = null)
     {
         $this->tag = $value;
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -126,7 +126,7 @@ class Response
      * @param string $certificateSerialNumber
      * @param \DateTimeImmutable|null $nextUpdate
      */
-    protected function __construct(DateTimeImmutable $thisUpdate, $certificateSerialNumber, DateTimeImmutable $nextUpdate = null)
+    protected function __construct(DateTimeImmutable $thisUpdate, $certificateSerialNumber, ?DateTimeImmutable $nextUpdate = null)
     {
         $this->thisUpdate = $thisUpdate;
         $this->certificateSerialNumber = $certificateSerialNumber;
@@ -142,7 +142,7 @@ class Response
      *
      * @return static
      */
-    public static function good(DateTimeImmutable $thisUpdate, $certificateSerialNumber, DateTimeImmutable $nextUpdate = null)
+    public static function good(DateTimeImmutable $thisUpdate, $certificateSerialNumber, ?DateTimeImmutable $nextUpdate = null)
     {
         $result = new static($thisUpdate, $certificateSerialNumber, $nextUpdate);
         $result->revoked = false;
@@ -160,7 +160,7 @@ class Response
      *
      * @return static
      */
-    public static function revoked(DateTimeImmutable $thisUpdate, $certificateSerialNumber, DateTimeImmutable $revokedOn, $revocationReason = self::REVOCATIONREASON_UNSPECIFIED, DateTimeImmutable $nextUpdate = null)
+    public static function revoked(DateTimeImmutable $thisUpdate, $certificateSerialNumber, DateTimeImmutable $revokedOn, $revocationReason = self::REVOCATIONREASON_UNSPECIFIED, ?DateTimeImmutable $nextUpdate = null)
     {
         $result = new static($thisUpdate, $certificateSerialNumber, $nextUpdate);
         $result->revoked = true;
@@ -178,7 +178,7 @@ class Response
      *
      * @return static
      */
-    public static function unknown(DateTimeImmutable $thisUpdate, $certificateSerialNumber, DateTimeImmutable $nextUpdate = null)
+    public static function unknown(DateTimeImmutable $thisUpdate, $certificateSerialNumber, ?DateTimeImmutable $nextUpdate = null)
     {
         $result = new static($thisUpdate, $certificateSerialNumber, $nextUpdate);
 


### PR DESCRIPTION
This PR fixes a few deprecated (PHP 8.4) implicitly nullable parameter declarations.

[Reference](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)