### PR TITLE
Add PHP 8.3 and 8.4 to CI's test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         include:
           - os: ubuntu-latest
             php-version: "5.5"


### PR DESCRIPTION
This PR adds PHP 8.3 and 8.4 to CI's test matrix. 

Note that I haven't changed any of the `include` matrix as I'm not entirely sure what's the reasoning behind its selection of OS/version, but I'm happy to do it once I have more details.